### PR TITLE
Support for manual session mgmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ bin/
 .gradle
 *.class
 build
+classes
+target
 .settings
 .classpath
 .project

--- a/src/main/java/org/lendingclub/neorx/NeoRxClientFacade.java
+++ b/src/main/java/org/lendingclub/neorx/NeoRxClientFacade.java
@@ -1,11 +1,9 @@
 package org.lendingclub.neorx;
 
-import org.neo4j.driver.v1.Driver;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.reactivex.Observable;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
 
 class NeoRxClientFacade extends NeoRxClient {
 
@@ -28,6 +26,10 @@ class NeoRxClientFacade extends NeoRxClient {
 	public Driver getDriver() {
 		return client.getDriver();
 	}
-	
-	
+
+    @Override
+    public Observable<JsonNode> execCypher(String cypher, Session session, Object... args) {
+        return client.execCypher(cypher, session, args);
+    }
+
 }

--- a/src/main/java/org/lendingclub/neorx/mock/MockNeoRxClient.java
+++ b/src/main/java/org/lendingclub/neorx/mock/MockNeoRxClient.java
@@ -9,9 +9,9 @@ import org.lendingclub.neorx.NeoRxClient;
 import org.neo4j.driver.v1.Driver;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.reactivex.Observable;
+import org.neo4j.driver.v1.Session;
 
 public class MockNeoRxClient extends NeoRxClient {
 
@@ -42,5 +42,10 @@ public class MockNeoRxClient extends NeoRxClient {
 
 	public Driver getDriver() {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Observable<JsonNode> execCypher(String cypher, Session session, Object... args) {
+		return execCypher(cypher, args);
 	}
 }


### PR DESCRIPTION
Adding support for batch inserts using manual session management. Before this change we were creating a new transaction for every call. By allowing the client to take responsibility of session management the client can decide when to commit transactions and cut down on db calls.

Also switched the observable creation to be async.